### PR TITLE
Offset DBM icon

### DIFF
--- a/AddOnSkins/Skins/AddOns/DBM.lua
+++ b/AddOnSkins/Skins/AddOns/DBM.lua
@@ -30,12 +30,12 @@ function AS:DBM(event, addon)
 
 						AS:SkinTexture(icon1, true)
 						icon1:ClearAllPoints()
-						icon1:SetPoint('BOTTOMRIGHT', frame, 'BOTTOMLEFT', AS:AdjustForTheme(-2), 1)
+						icon1:SetPoint('BOTTOMRIGHT', frame, 'BOTTOMLEFT', AS:AdjustForTheme(-1), 1)
 						icon1:SetSize(iconSize, iconSize)
 
 						AS:SkinTexture(icon2, true)
 						icon2:ClearAllPoints()
-						icon2:SetPoint('BOTTOMLEFT', frame, 'BOTTOMRIGHT', AS:AdjustForTheme(2), 1)
+						icon2:SetPoint('BOTTOMLEFT', frame, 'BOTTOMRIGHT', AS:AdjustForTheme(1), 1)
 						icon2:SetSize(iconSize, iconSize)
 
 						AS:SetInside(tbar, frame)


### PR DESCRIPTION
Offset should be 1, not 2. As you only need to adjust for one side of the border.

See attached image: https://media.discordapp.net/attachments/225365755212988416/968235579261198396/unknown.png