### PR TITLE
[Fix] Update RaiderIO hooks

### DIFF
--- a/AddOnSkins/Skins/AddOns/RaiderIO.lua
+++ b/AddOnSkins/Skins/AddOns/RaiderIO.lua
@@ -7,9 +7,19 @@ function AS:RaiderIO()
 	if _G.RaiderIO_CustomDropDownListMenuBackdrop then
 		AS:SkinTooltip(_G.RaiderIO_CustomDropDownListMenuBackdrop)
 	end
+	
+	if _G.Raiderio_CustomDropDownListMenuBackdrop then
+		AS:SkinTooltip(_G.Raiderio_CustomDropDownListMenuBackdrop)
+	end
 
+	
 	_G.PVEFrame:HookScript("OnShow", function(self)
-		if not _G.RaiderIO_ProfileTooltip.IsSkinned then
+		if _G.Raiderio_ProfileTooltip and not _G.Raiderio_ProfileTooltip.IsSkinned then
+			AS:SkinFrame(_G.Raiderio_ProfileTooltip)
+
+			_G.Raiderio_ProfileTooltip.IsSkinned = true
+		end
+		if _G.RaiderIO_ProfileTooltip and not _G.RaiderIO_ProfileTooltip.IsSkinned then
 			AS:SkinFrame(_G.RaiderIO_ProfileTooltip)
 
 			_G.RaiderIO_ProfileTooltip.IsSkinned = true


### PR DESCRIPTION
RaiderIO addon had different names; one was RaiderIO, the new packaging is "Raiderio", notice the difference in the end.