### PR TITLE
Fix window anchor for ExtendendCharacterStats

### DIFF
--- a/AddOnSkins/Skins/AddOns/ExtendedCharacterStats.lua
+++ b/AddOnSkins/Skins/AddOns/ExtendedCharacterStats.lua
@@ -3,8 +3,8 @@ local AS, L, S, R = unpack(AddOnSkins)
 function R:ExtendedCharacterStats()
 	-- Main frame
 	ECS_StatsFrame:ClearAllPoints()
-	ECS_StatsFrame:Point('RIGHT', _G.CharacterFrame, 149, 32)
-	ECS_StatsFrame:SetHeight(424)
+	ECS_StatsFrame:Point('LEFT', _G.CharacterFrame, 352, 32)
+	ECS_StatsFrame:SetHeight(425)
 	S:HandleFrame(ECS_StatsFrame)
 
 	-- Misc buttons


### PR DESCRIPTION
Hey there,

When changing the width of the ECS window in its settings, it usually expands to the right (without AddOnSkins).

With AddOnSkins however it a) overlaps with the character frame and b) extends to the left.

This PR fixes this and also changes the default height to match the character frame height.

Fixes #243
Fixes https://github.com/BreakBB/ExtendedCharacterStats/issues/324